### PR TITLE
Fix generation of inner tar paths

### DIFF
--- a/bin/make_studyvisit_archive
+++ b/bin/make_studyvisit_archive
@@ -81,7 +81,12 @@ def write_archive(
     with tarfile.open(dest_path, "w") as tar:
         # order of member in archive is significant, sort by path
         for p in tqdm(sorted(content), 'Composing archive', unit=' files'):
-            tinfo = tar.gettarinfo(name=p)
+            p_rel = p.relative_to(input_base_dir)
+            tinfo = tar.gettarinfo(
+                name=p,
+                # use normalized base dir + path relative to input dir
+                arcname=Path(archive_content_base_dir, *p_rel.parts)
+            )
             # adjust properties to make archive builds reproducible
             tinfo = normalize_tarinfo(
                 tinfo,
@@ -95,8 +100,6 @@ def write_archive(
 
 
 def normalize_tarinfo(tinfo, archive_path, timestamp):
-    # strip first level and replace with generated archive root dir name
-    tinfo.name = str(Path(archive_path, *Path(tinfo.name).parts[1:]))
     # be safe
     tinfo.uid = 0
     tinfo.gid = 0

--- a/tests/modules/make_studyvisit_archive.py
+++ b/tests/modules/make_studyvisit_archive.py
@@ -1,0 +1,1 @@
+../../bin/make_studyvisit_archive

--- a/tests/test_path_handling.py
+++ b/tests/test_path_handling.py
@@ -1,0 +1,24 @@
+
+import sys
+import tarfile
+from pathlib import Path
+
+from .modules.make_studyvisit_archive import main
+
+
+def test_path_handling(tmp_path):
+    base_dir = tmp_path / 'input' / 'd_1' / 'd_1_1' / 'd_1_1_1'
+    base_dir.mkdir(parents=True)
+    (base_dir / 'file1.txt').write_text('content 1')
+    (base_dir / 'file2.txt').write_text('content 2')
+
+    output_base_dir = tmp_path / 'output'
+
+    study_id, visit_id = 'study_1', 'visit_1'
+    main(str(base_dir), str(output_base_dir), study_id, visit_id)
+
+    tar_file = tarfile.open(output_base_dir / study_id / f'{visit_id}_dicom.tar')
+    assert tar_file.getnames() == [
+        f'{study_id}_{visit_id}/file1.txt',
+        f'{study_id}_{visit_id}/file2.txt',
+    ]


### PR DESCRIPTION
This changes the behavior of `make_studyvisit_archive` so that the tar file always contains paths relative to the directory specified.

E.g., for the following file tree:

```
/home/mszczepanik/Documents/dicom-samples/dicomdir
└── 01
    └── MR000000.dcm
```

running
```
❱ make_studyvisit_archive ~/Documents/dicom-samples/dicomdir -o /tmp/exports --id foo bar
```

should now generate:

```
❱ tar -tvf /tmp/exports/foo/baz_dicom.tar
-rw-r--r-- root/root  10823982 2024-04-26 12:40 foo_baz/01/MR000000.dcm
```

whereas previously it would only replace the first path component, and generate:

```
❱ tar -tvf /tmp/exports/foo/baz_dicom.tar
-rw-r--r-- root/root  10823982 2024-04-26 12:40 foo_baz/mszczepanik/Documents/dicom-samples/dicomdir/01/MR000000.dcm

```

Related: psychoinformatics-de/inm-icf-utilities/issues/53

<hr>

Please note that the orthanc exported zip file by default seems to include the following structure:
```
<orthanc study id>.zip
  <PatientID> <PatientName>
    <AccessionNumber> <StudyDescription>
      <Modality> <ProtocolName>
```
so depending on how you extract it before running `make_studyvisit_archive`, you may want the tar-generating script to discard more than the top level - or just point it to *within* the structure laid out above. In any case, I would suggest that you try the version updated by this PR on your actual data, look into the generated tarball, see if that's what you want and tweak accordingly, if needed.